### PR TITLE
fix: adding a non-empty string to the arguments fixes this issue in ie 1...

### DIFF
--- a/coffee/mediaCheck.coffee
+++ b/coffee/mediaCheck.coffee
@@ -4,7 +4,7 @@ window.mediaCheck = (options) ->
   createListener = undefined
   convertEmToPx = undefined
   getPXValue = undefined
-  hasMatchMedia = window.matchMedia isnt `undefined` and !!window.matchMedia("").addListener
+  hasMatchMedia = window.matchMedia isnt `undefined` and !!window.matchMedia("!").addListener
 
   if hasMatchMedia
     mqChange = (mq, options) ->


### PR DESCRIPTION
...0 and 11
