### PR TITLE
Prepare for publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
+npm-debug.log
 
 .sass-cache
 css

--- a/package.json
+++ b/package.json
@@ -1,7 +1,18 @@
 {
-  "name": "mediaCheck",
+  "name": "media-check",
   "version": "0.4.6",
+  "description": "This is a simple wrapper around matchMedia to run code on entry and exit from media queries. It also uses browser resize as a fallback for browsers that don't support matchMedia.",
+  "author": "Rob Tarr",
+  "license": "CC-BY-SA-3.0",
   "homepage": "http://github.com/sparkbox/mediaCheck",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sparkbox/mediaCheck.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sparkbox/mediaCheck/issues"
+  },
+  "main": "js/mediaCheck.js",
   "scripts": {
     "test": "karma start --single-run",
     "start": "npm-watch",
@@ -19,6 +30,14 @@
       "extensions": "coffee"
     }
   },
+  "keywords": [
+    "matchMedia",
+    "media",
+    "query",
+    "event",
+    "listener"
+  ],
+  "dependencies": {},
   "devDependencies": {
     "coffee-script": "^1.11.1",
     "jasmine-core": "^2.5.2",
@@ -30,5 +49,9 @@
     "phantomjs-prebuilt": "^2.1.13",
     "prepend-file": "^1.3.0",
     "uglify-js": "^2.7.3"
-  }
+  },
+  "files": [
+    "js/mediaCheck.js",
+    "readme.md"
+  ]
 }


### PR DESCRIPTION
Resolves #37

Few things to be aware of:
- Capital letters are not permissible in the `name` field of the package, so I changed it to `media-check`.
- Your script is not a CommonJS module, so it won't be easily`require`able. If/when you do decide to make it CJS-compatible, it will have to be bundled for testing.
- The `files` field in `package.json` defines what files are included when someone `npm install`s mediaCheck. The minified version is not included in the package, as this is discouraged by npm.

@robtarr Let me know if you have any questions. Otherwise, it's ready for merge and `npm publish`.
